### PR TITLE
READMEの案内そのままだとインストールできない

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ```sh
 $ git clone https://github.com/skanehira/spr
-$ cd spr && go install ./...
+$ cd spr && go install ./cmd/spr
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ```sh
 $ git clone https://github.com/skanehira/spr
-$ cd spr && go install
+$ cd spr && go install ./...
 ```
 
 ## Usage

--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -44,7 +44,7 @@ var indexHTML = `
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <title>spr</title>
+  <title>mpr</title>
 </head>
 <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.41.1/swagger-ui.css" >
@@ -72,6 +72,7 @@ const app = new Vue({
       const resp = JSON.parse(ev.data)
       if (!isFirst) {
         this.ui = SwaggerUIBundle({
+          url : resp.fileName,
           dom_id: '#ui',
           deepLinking: true,
           presets: [
@@ -83,7 +84,6 @@ const app = new Vue({
           ],
           layout: "StandaloneLayout"
         })
-		this.ui.specActions.updateSpec(resp.message)
         isFirst = true
         return
       }

--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -184,15 +184,8 @@ func main() {
 		}
 		defer c.Close()
 
-		b, err := ioutil.ReadFile(fileName)
-		if err != nil {
-			log.Println(err)
-			return
-		}
-
 		resp := map[string]interface{}{
 			"fileName": fileName,
-			"message":  string(b),
 		}
 		if err := c.WriteJSON(resp); err != nil {
 			log.Println(err)

--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -44,7 +44,7 @@ var indexHTML = `
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <title>mpr</title>
+  <title>spr</title>
 </head>
 <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.41.1/swagger-ui.css" >
@@ -72,7 +72,6 @@ const app = new Vue({
       const resp = JSON.parse(ev.data)
       if (!isFirst) {
         this.ui = SwaggerUIBundle({
-          url : resp.fileName,
           dom_id: '#ui',
           deepLinking: true,
           presets: [
@@ -84,6 +83,7 @@ const app = new Vue({
           ],
           layout: "StandaloneLayout"
         })
+		this.ui.specActions.updateSpec(resp.message)
         isFirst = true
         return
       }

--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -184,8 +184,15 @@ func main() {
 		}
 		defer c.Close()
 
+		b, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
 		resp := map[string]interface{}{
 			"fileName": fileName,
+			"message":  string(b),
 		}
 		if err := c.WriteJSON(resp); err != nil {
 			log.Println(err)


### PR DESCRIPTION
READMEそのままコピペだとインストールできなかったので修正の提案です。(MAC,Windowsで動作確認済)
過剰な説明に見える印象を与えるかもしれないので、マージするかはお任せします。
ツール自体はとても軽量に動作しました、最高です。

```
$ cd spr && go install
no Go files in C:\Users\ITO\project\swagger-preview
```